### PR TITLE
Fix pre-commit hook error with non-built-in packages

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,3 +3,5 @@
   description: render jinja2 templates to embedd python code directly from module using pdoc.
   entry: jinja2pdoc
   language: python
+  types: [jinja]
+  files: ^$

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Create a markdown file with `docstrings` and `source code` from `pathlib.Path` u
 ### Python
 
 ````python
-from jinja2_pdoc import jinja2, Jinja2Pdoc
+from jinja2_pdoc import Environment
 
-env = jinja2.Environment(extensions=[Jinja2Pdoc])
+env = Environment()
 
 s = """
     # jinja2-pdoc
@@ -165,19 +165,23 @@ Usage: jinja2pdoc [OPTIONS] [FILES]...
   To ignore the frontmatter section use the `--no-meta` flag.
 
 Options:
-  -o, --output PATH           output directory for files, if no 'filename' is
-                              provided in the frontmatter.  [default: cwd]
-  -e, --encoding TEXT         encoding of the files  [default: utf-8]
-  -s, --suffixes TEXT         suffixes which will be removed from templates,
-                              if no 'filename' is provided in the frontmatter
-                              [default: .jinja2, .j2]
-  --fail-fast                 exit on first error when rendering multiple file
-  --meta / --no-meta          parse frontmatter from the template, to search
-                              for 'filename'  [default: meta]
-  --rerender / --no-rerender  Each file is rendered only once.  [default: no-
-                              rerender]
-  --silent                    suppress console output
-  --help                      Show this message and exit.
+  -o, --output PATH             output directory for files, if no 'filename'
+                                is provided in the frontmatter.  [default:
+                                cwd]
+  -e, --encoding TEXT           encoding of the files  [default: utf-8]
+  -s, --suffixes TEXT           suffixes which will be removed from templates,
+                                if no 'filename' is provided in the
+                                frontmatter  [default: .jinja2, .j2]
+  --fail-fast                   exit on first error when rendering multiple
+                                file
+  --meta / --no-meta            parse frontmatter from the template, to search
+                                for 'filename'  [default: meta]
+  --rerender / --no-rerender    Each file is rendered only once.  [default:
+                                no-rerender]
+  --silent                      suppress console output
+  --load-path / --no-load-path  add the current working directory to path
+                                [default: load-path]
+  --help                        Show this message and exit.
 ```
 
 ```console
@@ -187,7 +191,7 @@ rendered         examples\example.md.jinja2......................   .\example.md
 
 ## pre-commit hook
 
-**Per default the hook is not registered to any `type` or `files`!**
+**Per default the hook is not registered to `files`!**
 
 To render all template files from `docs` using `.pre-commit-config.yaml` add the following.
 
@@ -196,7 +200,7 @@ You may add a `frontmatter` section at the beginning of in your templates to spe
 ```yaml
 repos:
   - repo: https://github.com/d-chris/jinja2_pdoc/
-    rev: v1.0.0
+    rev: v1.1.0
     hooks:
       - id: jinja2pdoc
         files: docs/.*\.jinja2$

--- a/jinja2_pdoc/cli.py
+++ b/jinja2_pdoc/cli.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from typing import Generator, List, Set
 
@@ -81,6 +82,7 @@ def jinja2pdoc(
     frontmatter: bool = True,
     rerender: bool = False,
     silent: bool = True,
+    load_path: bool = False,
 ) -> None:
     """
     Render jinja2 one or multiple template files, wildcards in filenames are allowed,
@@ -93,7 +95,12 @@ def jinja2pdoc(
     To ignore the frontmatter section use the `--no-meta` flag.
     """
 
-    root = Path(output) if output else Path.cwd()
+    cwd = Path.cwd()
+
+    if load_path and str(cwd) not in sys.path:
+        sys.path.append(str(cwd))
+
+    root = Path(output) if output else cwd
 
     env = Environment()
 
@@ -194,8 +201,22 @@ def jinja2pdoc(
     show_default=True,
     help="suppress console output",
 )
+@click.option(
+    "--load-path/--no-load-path",
+    default=True,
+    show_default=True,
+    help="add the current working directory to path",
+)
 def cli(**kwargs):
-    return jinja2pdoc(*kwargs.pop("files"), **kwargs)
+
+    files = kwargs.pop("files", ())
+
+    if not files:
+        raise click.UsageError("no files provided")
+
+    raise SystemExit(
+        jinja2pdoc(*files, **kwargs),
+    )
 
 
 if __name__ == "__main__":

--- a/jinja2_pdoc/cli.py
+++ b/jinja2_pdoc/cli.py
@@ -131,7 +131,7 @@ def jinja2pdoc(
         try:
             echo("rendering", file, render_file(file), silent)
         except Exception as e:
-            echo(e, file, "")
+            echo(e, file, "", silent)
 
             if fail_fast:
                 return 1
@@ -209,14 +209,12 @@ def jinja2pdoc(
 )
 def cli(**kwargs):
 
-    files = kwargs.pop("files", ())
+    result = jinja2pdoc(*kwargs.pop("files"), **kwargs)
 
-    if not files:
-        raise click.UsageError("no files provided")
+    if result == -1 and kwargs["silent"] is False:
+        click.echo("No files found.")
 
-    raise SystemExit(
-        jinja2pdoc(*files, **kwargs),
-    )
+    raise SystemExit(result)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ testpaths = "tests"
 addopts = [
   "--random-order",
   "--color=yes",
-  "-s",
   "--cov=jinja2_pdoc",
   "--cov-report=term-missing:skip-covered",
   "--cov-report=xml",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,10 +8,28 @@ def test_cli_folder(tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["examples/*.jinja2", "--output", str(tmp_path)],
+        [
+            "examples/*.jinja2",
+            "--output",
+            str(tmp_path),
+        ],
     )
     assert result.exit_code == 0
+    assert "rendering" in result.output
     assert tmp_path.joinpath("example.md").is_file()
+
+
+def test_cli_nofile(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--output",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == -1
+    assert result.output == "No files found.\n"
 
 
 def test_main(tmp_path):
@@ -50,6 +68,7 @@ def test_jinja2pdoc_fail(mocker, tmp_path, files, failfast):
             output=tmp_path,
             fail_fast=failfast,
             rerender=True,
+            silent=False,
         )
         == 1
     )


### PR DESCRIPTION
The pre-commit hook in the repository raises a RuntimeError when it encounters non-built-in packages. This pull request fixes the issue by updating the pre-commit hook to handle non-built-in packages correctly. Additionally, a new CLI test has been added to ensure the fix is working as expected. This resolves issue #11.