### PR TITLE
Enhance PdocStr functionality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: add-trailing-comma
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 2.4.3
+    rev: v2.4.3
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/tox-dev/tox-ini-fmt
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.19.0"
+    rev: "1.19.1"
     hooks:
       - id: blacken-docs
         files: pathlibutil/

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ optional `str` functions can be added to `<pdoc_attr>` with a dot
 - `indent` - format code with 2 spaces for indentation, see `autopep8.fix_code`
 - `upper` - converts to upper case
 - `lower` - converts to lower case
+- `nodoc` - removes shebang and docstring
 
 Example:
 
@@ -204,6 +205,20 @@ repos:
     hooks:
       - id: jinja2pdoc
         files: docs/.*\.jinja2$
+```
+
+Use `additional_dependencies` to add extra dependencies to the pre-commit environment. Example see below.
+
+> This is necessary when a module or source code rendered into your template contains modules that are not part of the standard library.
+
+```yaml
+repos:
+  - repo: https://github.com/d-chris/jinja2_pdoc/
+    rev: v1.1.0
+    hooks:
+      - id: jinja2pdoc
+        files: docs/.*\.jinja2$
+        additional_dependencies: [pathlibutil]
 ```
 
 ## Dependencies

--- a/docs/__main__.py
+++ b/docs/__main__.py
@@ -104,4 +104,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    SystemExit(main())
+    raise SystemExit(main())

--- a/jinja2_pdoc/cli.py
+++ b/jinja2_pdoc/cli.py
@@ -102,7 +102,9 @@ def jinja2pdoc(
 
     root = Path(output) if output else cwd
 
-    env = Environment()
+    env = Environment(
+        keep_trailing_newline=True,
+    )
 
     def render_file(file):
         template = file.read_text(encoding)

--- a/poetry.lock
+++ b/poetry.lock
@@ -565,13 +565,13 @@ files = [
 
 [[package]]
 name = "tox"
-version = "4.23.0"
+version = "4.23.2"
 description = "tox is a generic virtualenv management and test command line tool"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tox-4.23.0-py3-none-any.whl", hash = "sha256:46da40afb660e46238c251280eb910bdaf00b390c7557c8e4bb611f422e9db12"},
-    {file = "tox-4.23.0.tar.gz", hash = "sha256:a6bd7d54231d755348d3c3a7b450b5bf6563833716d1299a1619587a1b77a3bf"},
+    {file = "tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38"},
+    {file = "tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c"},
 ]
 
 [package.dependencies]
@@ -586,6 +586,9 @@ pyproject-api = ">=1.8"
 tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
 typing-extensions = {version = ">=4.12.2", markers = "python_version < \"3.11\""}
 virtualenv = ">=20.26.6"
+
+[package.extras]
+test = ["devpi-process (>=1.0.2)", "pytest (>=8.3.3)", "pytest-mock (>=3.14)"]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
- Keep trailing newline of templates while rendering.
- Add 'nodoc' method to PdocStr for removing shebang and docstring
- Update tests to cover new PdocStr methods and improve naming conventions
- Update pre-commit configuration